### PR TITLE
Fix backspace handling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -279,7 +279,7 @@ class AutoCompletion(GObject.GObject):
         if Gdk.keyval_name(event.keyval) == 'BackSpace':
             cursor.backward_chars(1)
             start = buffer.get_iter_at_mark(buffer.get_insert())
-            char = buffer.get_text(start, cursor)
+            char = buffer.get_text(start, cursor, include_hidden_chars=True)
             buffer.delete(start, cursor)
             if char == self.activation_char:
                 completion_window.destroy()


### PR DESCRIPTION
Apparently the pyGTK API has changed, perhaps this was a default parameter previously and is a mandatory parameter now. The fix provides the missing parameter.

Without this fix, the following error is logged:

```
Traceback (most recent call last):
  File "[cut]AppData\Roaming\zim\data\zim\plugins\zim-tag-autocompletion\__init__.py", line 282, in do_key_press
    char = buffer.get_text(start, cursor)
TypeError: Gtk.TextBuffer.get_text() takes exactly 4 arguments (3 given)
```
